### PR TITLE
add asbites, remove asdecodedhex, fix crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,13 @@ CLASSES
      |      Returns num_bits
      |      of bits as 90k time
      |  
-     |  asdecodedhex(self, num_bits)
-     |      Returns num_bits of bits
-     |      from hex decoded to bytes
+     |  asbites(self, num_bits)
+     |      Returns num_bits
+     |      of bits as bytes
+     |  
+     |  astext(self, num_bits)
+     |      Returns num_bits
+     |      of bits as text
      |  
      |  asflag(self, num_bits=1)
      |      Returns one bit as True or False

--- a/bitn.py
+++ b/bitn.py
@@ -40,13 +40,24 @@ class BitBin:
         """
         return hex(self.asint(num_bits))
 
-    def asdecodedhex(self, num_bits):
+    def asbites(self, num_bits):
         """
-        Returns num_bits of bits
-        from hex decoded to bytes
+        Returns num_bits
+        of bits as bytes
         """
         k = self.asint(num_bits)
-        return bytearray.fromhex(hex(k)[2:]).decode()
+        nibbles = int(num_bits / 4)
+        return bytearray.fromhex(f"{k:0{nibbles}x}")
+
+    def astext(self, num_bits, stop_at_null=True, encoding="latin-1", errors="strict"):
+        """
+        Returns num_bits
+        of bits as text
+        """
+        text = self.asbites(num_bits).decode(encoding, errors)
+        if stop_at_null:
+            return text.split("\0")[0]
+        return text
 
     def asflag(self, num_bits=1):
         """


### PR DESCRIPTION
This PR enables retrieving bytearrays and text from the bitbin, I can use that for my MPU parsing.
`asbites(num_bits)` returns a bytearray.
`astext(num_bits)` is a drop-in replacement for `asdecodedhex(num_bits)`.

If will push a commit to [threefive](https://github.com/futzu/SCTE35-threefive) to implement this replacement (the three lines you mentioned in your comment).

This also fixes a potential crash in `fromhex()` that would happen if `hex()` returned a odd number of nibbles, depending on the content.
